### PR TITLE
feat[index]: Add support for inverted indexes

### DIFF
--- a/src/Collection/Index/Factory.php
+++ b/src/Collection/Index/Factory.php
@@ -38,6 +38,7 @@ final class Factory
             'geo' => GeoSpatialIndex::class,
             'skiplist' => SkipListIndex::class,
             'ttl' => TTLIndex::class,
+            'inverted' => InvertedIndex::class
         ];
 
         if (!array_key_exists($attributes['type'], $indexes)) {

--- a/src/Collection/Index/Factory.php
+++ b/src/Collection/Index/Factory.php
@@ -62,6 +62,10 @@ final class Factory
             return new TTLIndex($attributes['fields'], $attributes['expireAfter'], $attributes);
         }
 
+        if ($attributes['type'] === 'inverted') {
+            return new InvertedIndex($attributes['fields'], $attributes);
+        }
+
         $class = $indexes[$attributes['type']];
         return new $class($attributes['fields'], $attributes);
     }

--- a/src/Collection/Index/HashIndex.php
+++ b/src/Collection/Index/HashIndex.php
@@ -11,6 +11,7 @@ use ArangoDB\Validation\Exceptions\InvalidParameterException;
  *
  * @package ArangoDB\Collection\Index
  * @author Lucas S. Vieira
+ * @deprecated
  */
 class HashIndex extends Index
 {

--- a/src/Collection/Index/Index.php
+++ b/src/Collection/Index/Index.php
@@ -21,42 +21,42 @@ class Index implements IndexInterface
      *
      * @var string
      */
-    protected $id;
+    protected string $id;
 
     /**
      * Index name.
      *
      * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Sparse
      *
      * @var bool
      */
-    protected $sparse;
+    protected bool $sparse;
 
     /**
      * Index type
      *
      * @var string
      */
-    protected $type;
+    protected string $type;
 
     /**
      * Unique constraint
      *
      * @var bool
      */
-    protected $unique;
+    protected bool $unique;
 
     /**
      * Fields of index
      *
      * @var array
      */
-    protected $fields;
+    protected array $fields;
 
     /**
      * Collection where the index belongs to
@@ -71,15 +71,15 @@ class Index implements IndexInterface
      *
      * @var bool
      */
-    protected $isNew;
+    protected bool $isNew;
 
     /**
      * Valid indexes types
      *
      * @var array
      */
-    protected static $indexTypes = [
-        'fulltext', 'general', 'geo', 'hash', 'persistent', 'skiplist', 'ttl', 'primary', 'edge'
+    protected static array $indexTypes = [
+        'fulltext', 'general', 'geo', 'hash', 'persistent', 'skiplist', 'ttl', 'primary', 'edge', 'inverted'
     ];
 
     /**
@@ -107,10 +107,10 @@ class Index implements IndexInterface
         $this->fields = $fields;
 
         // Default values;
-        $this->id = isset($attributes['id']) ? $attributes['id'] : '';
-        $this->name = isset($attributes['name']) ? $attributes['name'] : '';
-        $this->unique = isset($attributes['unique']) ? $attributes['unique'] : false;
-        $this->sparse = isset($attributes['sparse']) ? $attributes['sparse'] : false;
+        $this->id = $attributes['id'] ?? '';
+        $this->name = $attributes['name'] ?? '';
+        $this->unique = $attributes['unique'] ?? false;
+        $this->sparse = $attributes['sparse'] ?? false;
         $this->isNew = !isset($attributes['id']);
     }
 

--- a/src/Collection/Index/Index.php
+++ b/src/Collection/Index/Index.php
@@ -85,7 +85,7 @@ class Index implements IndexInterface
     /**
      * Index constructor.
      *
-     * @param string $type The index type. Must be one of following values: 'fulltext', 'general', 'geo', 'hash', 'persistent', 'skiplist' or 'ttl'
+     * @param string $type The index type. Must be one of following values: 'fulltext', 'general', 'geo', 'hash', 'persistent', 'skiplist', 'inverted' or 'ttl'
      * @param array $fields An array of attribute names. Normally with just one attribute.
      *
      * @param array $attributes
@@ -97,10 +97,20 @@ class Index implements IndexInterface
             throw new InvalidParameterException("type", $type);
         }
 
+        $fieldNames = [];
+
         foreach ($fields as $key => $field) {
-            if (!is_string($field)) {
-                throw new InvalidParameterException("fields[$key]", $field);
+            if (is_string($field)) {
+                array_push($fieldNames, $field);
+                continue;
             }
+
+            if (is_array($field)) {
+                array_push($fieldNames, $field['name']);
+                continue;
+            }
+
+            throw new InvalidParameterException("fields[$key]", $field);
         }
 
         $this->type = $type;

--- a/src/Collection/Index/InvertedIndex.php
+++ b/src/Collection/Index/InvertedIndex.php
@@ -10,8 +10,21 @@ use ArangoDB\Validation\Exceptions\InvalidParameterException;
 * @package ArangoDB\Collection\Index
 * @author Lucas S. Vieira
 */
-class InvertedIndex extends Index
+final class InvertedIndex extends Index
 {
+    /**
+     * Default options for inverted index
+     *
+     * @var array
+     */
+    protected array $defaultOptions = [
+        'unique' => true,
+        'sparse' => true,
+        'analyzer' => "identity",
+        'inBackground' => true, // Keep the collection available for writes during the index creation
+        'parallelism' => 2,
+    ];
+
     /**
      * InvertedIndex constructor
      *

--- a/src/Collection/Index/InvertedIndex.php
+++ b/src/Collection/Index/InvertedIndex.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ArangoDB\Collection\Index;
+
+use ArangoDB\Validation\Exceptions\InvalidParameterException;
+
+/**
+* Inverted index representation
+*
+* @package ArangoDB\Collection\Index
+* @author Lucas S. Vieira
+*/
+class InvertedIndex extends Index
+{
+    /**
+     * InvertedIndex constructor
+     *
+     * @param array $fields Fields for which the index applies to
+     * @param array $attributes Index $attributes
+     *
+     * @throws InvalidParameterException
+     */
+    public function __construct(array $fields, array $attributes = [])
+    {
+        parent::__construct('inverted', $fields, $attributes);
+    }
+}

--- a/src/Collection/Index/SkipListIndex.php
+++ b/src/Collection/Index/SkipListIndex.php
@@ -11,6 +11,7 @@ use ArangoDB\Validation\Exceptions\InvalidParameterException;
  *
  * @package ArangoDB\Collection\Index
  * @author Lucas S. Vieira
+ * @deprecated
  */
 final class SkipListIndex extends HashIndex
 {

--- a/tests/Collection/CollectionTest.php
+++ b/tests/Collection/CollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Unit\Collection;
 
+use ArangoDB\Collection\Index\InvertedIndex;
 use ArangoDB\Collection\KeyType;
 use Unit\TestCase;
 use GuzzleHttp\Psr7\Response;
@@ -36,20 +37,20 @@ class CollectionTest extends TestCase
         parent::tearDown();
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $collection = new Collection('any', $this->getConnectionObject()->getDatabase());
         $this->assertInstanceOf(Collection::class, $collection);
         $this->assertObjectHasProperty('connection', $collection);
     }
 
-    public function testGetDatabase()
+    public function testGetDatabase(): void
     {
         $collection = new Collection('any', $this->getConnectionObject()->getDatabase());
         $this->assertInstanceOf(Database::class, $collection->getDatabase());
     }
 
-    public function testGetter()
+    public function testGetter(): void
     {
         $collection = new Collection('any', $this->getConnectionObject()->getDatabase());
         $this->assertEquals('any', $collection->name);
@@ -60,7 +61,7 @@ class CollectionTest extends TestCase
         $this->assertNull($collection->randomProperty);
     }
 
-    public function testSetter()
+    public function testSetter(): void
     {
         $collection = new Collection('any', $this->getConnectionObject()->getDatabase());
         $this->assertEquals('any', $collection->name);
@@ -74,27 +75,27 @@ class CollectionTest extends TestCase
         $this->assertNull($collection->randomProperty);
     }
 
-    public function testSetterThrowException()
+    public function testSetterThrowException(): void
     {
         $collection = new Collection('any', $this->getConnectionObject()->getDatabase());
         $this->expectException(\Exception::class);
         $collection->randomProperty = true;
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase(), ['isSystem' => true]);
         $this->assertIsString((string)$collection);
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase());
         $this->assertEquals('testing_collection_coll', $collection->getName());
         $this->assertEquals($collection->name, $collection->getName());
     }
 
-    public function testGetId()
+    public function testGetId(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase());
         $this->assertNull($collection->getId());
@@ -104,19 +105,19 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testGetStatus()
+    public function testGetStatus(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase());
         $this->assertEquals(0, $collection->getStatus());
     }
 
-    public function testGetDescription()
+    public function testGetDescription(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase());
         $this->assertEquals('unknown', $collection->getStatusDescription());
     }
 
-    public function testIsSystem()
+    public function testIsSystem(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase());
         $this->assertFalse($collection->isSystem());
@@ -125,20 +126,20 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->isSystem());
     }
 
-    public function testGetAttributes()
+    public function testGetAttributes(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase(), ['isSystem' => true]);
         $this->assertIsArray($collection->getAttributes());
         $this->assertTrue($collection->getAttributes()['isSystem']);
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $collection = new Collection('testing_collection_coll', $this->getConnectionObject()->getDatabase(), ['isSystem' => true]);
         $this->assertJson(json_encode($collection));
     }
 
-    public function testGetGloballyUniqueId()
+    public function testGetGloballyUniqueId(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -152,7 +153,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testAddFullTextIndex()
+    public function testAddFullTextIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -167,7 +168,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('fulltext', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddGeoSpatialIndex()
+    public function testAddGeoSpatialIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -182,7 +183,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('geo', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddHashIndex()
+    public function testAddHashIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -197,7 +198,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('hash', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddPersistentIndex()
+    public function testAddPersistentIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -212,7 +213,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('persistent', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddSkipListIndex()
+    public function testAddSkipListIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -227,7 +228,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('skiplist', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddTTLIndex()
+    public function testAddTTLIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -242,7 +243,22 @@ class CollectionTest extends TestCase
         $this->assertEquals('ttl', $collection->getIndexes()->last()->getType());
     }
 
-    public function testAddIndexThrowDatabaseException()
+    public function testAddInvertedIndex(): void
+    {
+        $db = new Database($this->getConnectionObject());
+        $collection = new Collection('test_save_coll', $db);
+
+        $this->assertTrue($collection->save());
+        $this->assertCount(1, $collection->getIndexes());
+
+        $index = new InvertedIndex(['complicated']);
+        $this->assertTrue($collection->addIndex($index));
+
+        $this->assertCount(2, $collection->getIndexes());
+        $this->assertEquals('inverted', $collection->getIndexes()->last()->getType());
+    }
+
+    public function testAddIndexThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -262,7 +278,7 @@ class CollectionTest extends TestCase
         $collection->addIndex($index);
     }
 
-    public function testAddIndexOnNewCollectionReturnFalse()
+    public function testAddIndexOnNewCollectionReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -271,7 +287,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($collection->addIndex($index));
     }
 
-    public function testDropIndex()
+    public function testDropIndex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -294,7 +310,7 @@ class CollectionTest extends TestCase
         $this->assertCount(1, $collection->getIndexes());
     }
 
-    public function testDropIndexOnNewCollectionReturnFalse()
+    public function testDropIndexOnNewCollectionReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -303,7 +319,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($collection->dropIndex($index));
     }
 
-    public function testDropNewIndexReturnFalse()
+    public function testDropNewIndexReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -317,7 +333,7 @@ class CollectionTest extends TestCase
     }
 
 
-    public function testDropNonExistentIndexReturnFalse()
+    public function testDropNonExistentIndexReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -336,7 +352,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($collection->dropIndex($fulltext));
     }
 
-    public function testDropIndexThrowDatabaseException()
+    public function testDropIndexThrowDatabaseException(): void
     {
         $index = new FullTextIndex(['complicated'], 3);
         $mocked = [
@@ -390,7 +406,7 @@ class CollectionTest extends TestCase
         $collection->dropIndex($list->last());
     }
 
-    public function testGetIndexes()
+    public function testGetIndexes(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -418,7 +434,7 @@ class CollectionTest extends TestCase
         $this->assertCount(1, $collection->getIndexes());
     }
 
-    public function testGetIndexesThrowDatabaseException()
+    public function testGetIndexesThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -434,7 +450,7 @@ class CollectionTest extends TestCase
         $indexes = $collection->getIndexes();
     }
 
-    public function testAll()
+    public function testAll(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -445,7 +461,7 @@ class CollectionTest extends TestCase
         $this->assertInstanceOf(CollectionCursor::class, $collection->all());
     }
 
-    public function testFindByKey()
+    public function testFindByKey(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -462,7 +478,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('testing', $doc->toArray()['document']);
     }
 
-    public function testFindByKeyReturnVertex()
+    public function testFindByKeyReturnVertex(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -479,7 +495,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('testing', $doc->toArray()['document']);
     }
 
-    public function testFindByKeyReturnFalse()
+    public function testFindByKeyReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -492,7 +508,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($doc);
     }
 
-    public function testFindByKeyThrowDatabaseException()
+    public function testFindByKeyThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -507,7 +523,7 @@ class CollectionTest extends TestCase
         $collection->findByKey("unknown");
     }
 
-    public function testSave()
+    public function testSave(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -520,7 +536,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testSaveWithNonDefaultOptions()
+    public function testSaveWithNonDefaultOptions(): void
     {
         $keyOptions = [
             'allowUserKeys' => false,
@@ -538,7 +554,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testSaveThrowDatabaseException()
+    public function testSaveThrowDatabaseException(): void
     {
         // Mock error
         $mock = new MockHandler([
@@ -555,7 +571,7 @@ class CollectionTest extends TestCase
         $collection->save();
     }
 
-    public function testDrop()
+    public function testDrop(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -571,7 +587,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($db->hasCollection('test_save_coll'));
     }
 
-    public function testDropReturnFalse()
+    public function testDropReturnFalse(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('coll_to_drop', $db);
@@ -579,7 +595,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($collection->drop());
     }
 
-    public function testDropThrowDatabaseException()
+    public function testDropThrowDatabaseException(): void
     {
         // Mock error
         $mock = new MockHandler([
@@ -596,7 +612,7 @@ class CollectionTest extends TestCase
         $collection->drop();
     }
 
-    public function testTruncate()
+    public function testTruncate(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_save_coll', $db);
@@ -620,7 +636,7 @@ class CollectionTest extends TestCase
         $this->assertFalse($db->hasCollection('test_save_coll'));
     }
 
-    public function testTruncateThrowDatabaseException()
+    public function testTruncateThrowDatabaseException(): void
     {
         // Mock error
         $mock = new MockHandler([
@@ -637,7 +653,7 @@ class CollectionTest extends TestCase
         $collection->truncate();
     }
 
-    public function testRename()
+    public function testRename(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_first_name', $db);
@@ -657,7 +673,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testRenameThrowDatabaseException()
+    public function testRenameThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -678,7 +694,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->rename('test_snd_name'));
     }
 
-    public function testRecalculateCount()
+    public function testRecalculateCount(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_first_name', $db);
@@ -691,7 +707,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($collection->drop());
     }
 
-    public function testRecalculateCountThrowDatabaseException()
+    public function testRecalculateCountThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -712,7 +728,7 @@ class CollectionTest extends TestCase
         $this->assertIsBool($collection->recalculateCount());
     }
 
-    public function testCount()
+    public function testCount(): void
     {
         $db = new Database($this->getConnectionObject());
         $collection = new Collection('test_first_name', $db);
@@ -727,7 +743,7 @@ class CollectionTest extends TestCase
         // TODO Make tests add with documents
     }
 
-    public function testCountThrowDatabaseException()
+    public function testCountThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -744,7 +760,7 @@ class CollectionTest extends TestCase
         $this->assertIsBool($collection->count());
     }
 
-    public function testGetChecksum()
+    public function testGetChecksum(): void
     {
         $db = new Database($this->getConnectionObject());
         $coll1 = new Collection('test_first', $db, ['checksum' => '7854980051561']);
@@ -763,7 +779,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($coll2->drop());
     }
 
-    public function testGetChecksumThrowDatabaseException()
+    public function testGetChecksumThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -780,7 +796,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('0', $collection->getChecksum());
     }
 
-    public function testGetRevision()
+    public function testGetRevision(): void
     {
         $db = new Database($this->getConnectionObject());
 
@@ -805,7 +821,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($coll2->drop());
     }
 
-    public function testGetRevisionThrowDatabaseException()
+    public function testGetRevisionThrowDatabaseException(): void
     {
         $mock = new MockHandler([
             new Response(200, [], json_encode(['result' => []])),
@@ -822,7 +838,7 @@ class CollectionTest extends TestCase
         $this->assertEquals('0', $collection->getRevision());
     }
 
-    public function testIsNew()
+    public function testIsNew(): void
     {
         $db = new Database($this->getConnectionObject());
         $coll1 = $db->createCollection('test_first');
@@ -841,7 +857,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($coll2->drop());
     }
 
-    public function testIsGraph()
+    public function testIsGraph(): void
     {
         $db = new Database($this->getConnectionObject());
         $coll = $db->createCollection('test_graph');

--- a/tests/Collection/CollectionTest.php
+++ b/tests/Collection/CollectionTest.php
@@ -2,7 +2,6 @@
 
 namespace Unit\Collection;
 
-use ArangoDB\Admin\Server;
 use ArangoDB\Collection\KeyType;
 use Unit\TestCase;
 use GuzzleHttp\Psr7\Response;

--- a/tests/Collection/Index/EdgeIndexTest.php
+++ b/tests/Collection/Index/EdgeIndexTest.php
@@ -8,14 +8,14 @@ use ArangoDB\Exceptions\IndexException;
 
 class EdgeIndexTest extends TestCase
 {
-    public function testGetCreateData()
+    public function testGetCreateData(): void
     {
         $index = new EdgeIndex(['custom_field' => 'any']);
         $this->expectException(IndexException::class);
         $data = $index->getCreateData();
     }
 
-    public function testGetType()
+    public function testGetType(): void
     {
         $index = new EdgeIndex(['custom_field' => 'any']);
         $this->assertEquals('edge', $index->getType());

--- a/tests/Collection/Index/FactoryTest.php
+++ b/tests/Collection/Index/FactoryTest.php
@@ -1,10 +1,9 @@
 <?php
 
-namespace Unit\Collection\GeneralIndex;
+namespace Unit\Collection\Index;
 
 use ArangoDB\Collection\Index\InvertedIndex;
 use Unit\TestCase;
-use ArangoDB\Collection\Index\Index;
 use ArangoDB\Collection\Index\Factory;
 use ArangoDB\Exceptions\IndexException;
 use ArangoDB\Collection\Index\TTLIndex;
@@ -35,7 +34,7 @@ class FactoryTest extends TestCase
         ];
     }
 
-    public function mockEdgeArray()
+    public function mockEdgeArray(): array
     {
         return [
             'fields' => [
@@ -51,7 +50,7 @@ class FactoryTest extends TestCase
         ];
     }
 
-    public function mockHashArray()
+    public function mockHashArray(): array
     {
         return [
             'fields' => [
@@ -177,67 +176,67 @@ class FactoryTest extends TestCase
         ];
     }
 
-    public function testFactoryMakesPrimaryIndex()
+    public function testFactoryMakesPrimaryIndex(): void
     {
         $index = Factory::factory($this->mockPrimaryArray());
         $this->assertInstanceOf(PrimaryIndex::class, $index);
     }
 
-    public function testFactoryMakesEdgeIndex()
+    public function testFactoryMakesEdgeIndex(): void
     {
         $index = Factory::factory($this->mockEdgeArray());
         $this->assertInstanceOf(EdgeIndex::class, $index);
     }
 
-    public function testFactoryMakesHashIndex()
+    public function testFactoryMakesHashIndex(): void
     {
         $index = Factory::factory($this->mockHashArray());
         $this->assertInstanceOf(HashIndex::class, $index);
     }
 
-    public function testFactoryMakesGeoSpatialIndex()
+    public function testFactoryMakesGeoSpatialIndex(): void
     {
         $index = Factory::factory($this->mockGeoSpatialArray());
         $this->assertInstanceOf(GeoSpatialIndex::class, $index);
     }
 
-    public function testFactoryMakesFullTextIndex()
+    public function testFactoryMakesFullTextIndex(): void
     {
         $index = Factory::factory($this->mockFullTextArray());
         $this->assertInstanceOf(FullTextIndex::class, $index);
     }
 
-    public function testFactoryMakesSkipListIndex()
+    public function testFactoryMakesSkipListIndex(): void
     {
         $index = Factory::factory($this->mockSkipListArray());
         $this->assertInstanceOf(SkipListIndex::class, $index);
     }
 
-    public function testFactoryMakesPersistentIndex()
+    public function testFactoryMakesPersistentIndex(): void
     {
         $index = Factory::factory($this->mockPersistentArray());
         $this->assertInstanceOf(PersistentIndex::class, $index);
     }
 
-    public function testFactoryMakesTTLIndex()
+    public function testFactoryMakesTTLIndex(): void
     {
         $index = Factory::factory($this->mockTTLArray());
         $this->assertInstanceOf(TTLIndex::class, $index);
     }
 
-    public function testFactoryMakesInvertedIndex()
+    public function testFactoryMakesInvertedIndex(): void
     {
         $index = Factory::factory($this->mockInvertedArray());
         $this->assertInstanceOf(InvertedIndex::class, $index);
     }
 
-    public function testFactoryMakesGenericIndex()
+    public function testFactoryMakesGenericIndex(): void
     {
         $this->expectException(IndexException::class);
         $index = Factory::factory($this->mockGenericArray());
     }
 
-    public function testFactoryThrowMissingParameterException()
+    public function testFactoryThrowMissingParameterException(): void
     {
         $attributes = $this->mockGenericArray();
         unset($attributes['type']);

--- a/tests/Collection/Index/FactoryTest.php
+++ b/tests/Collection/Index/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Unit\Collection\GeneralIndex;
 
+use ArangoDB\Collection\Index\InvertedIndex;
 use Unit\TestCase;
 use ArangoDB\Collection\Index\Index;
 use ArangoDB\Collection\Index\Factory;
@@ -161,6 +162,21 @@ class FactoryTest extends TestCase
         ];
     }
 
+    public function mockInvertedArray(): array
+    {
+        return [
+            'fields' => [
+                'my_field',
+            ],
+            'id' => 'coll/0',
+            'name' => 'inverted_idx',
+            'sparse' => true,
+            'unique' => false,
+            'type' => 'inverted',
+            'selectivityEstimate' => 0.015
+        ];
+    }
+
     public function testFactoryMakesPrimaryIndex()
     {
         $index = Factory::factory($this->mockPrimaryArray());
@@ -207,6 +223,12 @@ class FactoryTest extends TestCase
     {
         $index = Factory::factory($this->mockTTLArray());
         $this->assertInstanceOf(TTLIndex::class, $index);
+    }
+
+    public function testFactoryMakesInvertedIndex()
+    {
+        $index = Factory::factory($this->mockInvertedArray());
+        $this->assertInstanceOf(InvertedIndex::class, $index);
     }
 
     public function testFactoryMakesGenericIndex()

--- a/tests/Collection/Index/HashIndexTest.php
+++ b/tests/Collection/Index/HashIndexTest.php
@@ -13,7 +13,7 @@ class HashIndexTest extends TestCase
         parent::setUp();
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $index = new HashIndex(['my_hash_attr']);
 
@@ -22,7 +22,7 @@ class HashIndexTest extends TestCase
         $this->assertEquals("hash", $index->getType());
     }
 
-    public function testIsDeduplicate()
+    public function testIsDeduplicate(): void
     {
         $index = new HashIndex(['my_hash_attr'], ['unique' => false, 'sparse' => false, 'deduplicate' => false]);
         $this->assertFalse($index->isUnique());
@@ -30,13 +30,13 @@ class HashIndexTest extends TestCase
         $this->assertFalse($index->isDeduplicate());
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $index = new HashIndex(['my_hash_attr']);
         $this->assertArrayHasKey('deduplicate', $index->toArray());
     }
 
-    public function testGetCreateData()
+    public function testGetCreateData(): void
     {
         $index = new HashIndex(['my_hash_attr']);
         $this->assertCount(5, $index->getCreateData());

--- a/tests/Collection/Index/IndexTest.php
+++ b/tests/Collection/Index/IndexTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Unit\Collection\GeneralIndex;
+namespace Unit\Collection\Index;
 
 use Unit\TestCase;
 use ArangoDB\Collection\Collection;
@@ -21,7 +21,7 @@ class IndexTest extends TestCase
         parent::tearDown();
     }
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $index = new Index("geo", ['location']);
 
@@ -34,25 +34,25 @@ class IndexTest extends TestCase
         $this->assertEquals("geo", $index->getType());
     }
 
-    public function testConstructorThrowInvalidParameterExceptionForInvalidType()
+    public function testConstructorThrowInvalidParameterExceptionForInvalidType(): void
     {
         $this->expectException(InvalidParameterException::class);
         $index = new Index("easy", ['location']);
     }
 
-    public function testConstructorThrowInvalidParameterExceptionForInvalidKey()
+    public function testConstructorThrowInvalidParameterExceptionForInvalidKey(): void
     {
         $this->expectException(InvalidParameterException::class);
         $index = new Index("fulltext", [154]);
     }
 
-    public function testToString()
+    public function testToString(): void
     {
         $index = new Index("skiplist", ['custom_field']);
         $this->assertIsString((string)$index);
     }
 
-    public function testGetAndSetCollection()
+    public function testGetAndSetCollection(): void
     {
         $collection = $this->getConnectionObject()->getDatabase()->createCollection('index_coll');
         $index = new Index("skiplist", ['custom_field']);
@@ -62,14 +62,14 @@ class IndexTest extends TestCase
         $this->assertInstanceOf(Collection::class, $index->getCollection());
     }
 
-    public function testJsonSerialize()
+    public function testJsonSerialize(): void
     {
         $collection = $this->getConnectionObject()->getDatabase()->createCollection('index_coll');
         $index = $collection->getIndexes()->first();
         $this->assertJson(json_encode($index));
     }
 
-    public function testIsNew()
+    public function testIsNew(): void
     {
         $index = new Index("skiplist", ['custom_field']);
         $this->assertTrue($index->isNew());
@@ -80,7 +80,7 @@ class IndexTest extends TestCase
         $this->assertFalse($index->isNew());
     }
 
-    public function testGetFields()
+    public function testGetFields(): void
     {
         $index = new Index("skiplist", ['custom_field']);
         $this->assertIsArray($index->getFields());
@@ -92,7 +92,7 @@ class IndexTest extends TestCase
         $this->assertEquals("_key", $index->getFields()[0]);
     }
 
-    public function testGetCreateData()
+    public function testGetCreateData(): void
     {
         $index = new Index("skiplist", ['custom_field']);
         $this->assertIsArray($index->getCreateData());

--- a/tests/Collection/Index/InvertedIndexTest.php
+++ b/tests/Collection/Index/InvertedIndexTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Unit\Collection\Index;
+
+use Unit\TestCase;
+use ArangoDB\Collection\Index\InvertedIndex;
+
+class InvertedIndexTest extends TestCase
+{
+    public function setUp(): void
+    {
+        $this->loadEnvironment();
+        parent::setUp();
+    }
+
+    public function testConstructor(): void
+    {
+        $index = new InvertedIndex(['my_idx_attribute']);
+        $this->assertTrue($index->isNew());
+        $this->assertEquals("inverted", $index->getType());
+    }
+
+    public function testToArray(): void
+    {
+        $index = new InvertedIndex(['my_idx_attribute'], ['unique' => false]);
+        $this->assertArrayHasKey('unique', $index->toArray());
+        $this->assertFalse($index->toArray()['unique']);
+    }
+}


### PR DESCRIPTION
Marks 'hash' and 'skiplist' indexes as deprecated as per ArangoDB 3.12 docs: https://docs.arangodb.com/stable/develop/http-api/indexes/persistent/